### PR TITLE
Update quicklinks section

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,9 +86,8 @@ root: .
         <div class="col-sm-4">
             <h2>Quick links</h2>
             <ul id="quick-links">
-                <li><a href="https://github.com/GarageGames/Torque3D/issues/new">Report an issue</a></li>
+                <li><a href="https://github.com/GarageGames/Torque3D/issues/new">Report an issue or suggest changes</a></li>
                 <li><a href="https://github.com/GarageGames/Torque3D/issues?labels=Final+review">Changes for final review</a></li>
-                <li><a href="http://garagegames.uservoice.com/forums/178972-torque-3d-mit/filters/top">Feature requests</a></li>
                 <li><a href="http://t3dci.org">Builds and CI</a></li>
             </ul>
         </div>


### PR DESCRIPTION
Old uservoice page was shut down(probably because no one used it) so updating the quicklinks to direct to the issues page of the repo for both issues and feature suggestions.